### PR TITLE
fix wrong container id on Linux

### DIFF
--- a/ge/ge_ckan/smoketest.sh
+++ b/ge/ge_ckan/smoketest.sh
@@ -2,15 +2,13 @@
 
 set -e
 
-# Get container id
-container=($(docker ps | awk '{ print $1 }'))
-container_id=${container[1]}
+export CKAN_CONTAINER=ckan
 
 # Get IP depending on the OS : IP of the VM on Mac OS, IP of the container on others
 if [[ `uname` == 'Darwin'* ]]; then
 	IP=$(docker-machine ip $(docker-machine active))
 else
-	IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}' ${container_id})
+	IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}' ${CKAN_CONTAINER})
 fi
 
 # get port

--- a/ge/ge_spagobi/run.sh
+++ b/ge/ge_spagobi/run.sh
@@ -17,11 +17,8 @@ docker build -t $SPAGOBI_IMAGE_NAME .
 # Run a MySQL Container for the SpagoBI Data
 docker run --name ${MYSQL_CONTAINER_NAME} -e MYSQL_USER=${MYSQL_USER} -e MYSQL_PASSWORD=${MYSQL_PASSWORD} -e MYSQL_DATABASE=${MYSQL_DATABASE} -e MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD} -d mysql
 
-# wait for mysql to be ready
-#sleep 10
-
 # Run the SpagoBI Container
-docker run --name ${SPAGOBI_CONTAINER_NAME} --link ${MYSQL_CONTAINER_NAME}:db -p 3360:3360 -P ${SPAGOBI_IMAGE_NAME}
+docker run --name ${SPAGOBI_CONTAINER_NAME} --link ${MYSQL_CONTAINER_NAME}:db -P ${SPAGOBI_IMAGE_NAME}
 
 # handle the case in which we build the SpagoBI container before finishing to build the mysql db container - ERROR 2003 (HY000): Can't connect to MySQL server
 result=$(docker inspect --format '{{ .State.ExitCode }}' ${SPAGOBI_CONTAINER_NAME})
@@ -29,5 +26,7 @@ result=$(docker inspect --format '{{ .State.ExitCode }}' ${SPAGOBI_CONTAINER_NAM
 while [ $result -ne 0 ]; do
 	sleep 5
 	docker rm -f ${SPAGOBI_CONTAINER_NAME}
-	docker run --name ${SPAGOBI_CONTAINER_NAME} --link ${MYSQL_CONTAINER_NAME}:db -p 3360:3360 -P ${SPAGOBI_IMAGE_NAME}
+	docker run --name ${SPAGOBI_CONTAINER_NAME} --link ${MYSQL_CONTAINER_NAME}:db -P ${SPAGOBI_IMAGE_NAME}
 done
+
+exit 0


### PR DESCRIPTION
Fix bug in smoketest.sh on Linux machines due to a mistake in getting the ckan container id
